### PR TITLE
adds restart kernel command

### DIFF
--- a/jupyter_ascending/handlers/jupyter_notebook.py
+++ b/jupyter_ascending/handlers/jupyter_notebook.py
@@ -29,6 +29,7 @@ from jupyter_ascending.json_requests import ExecuteAllRequest
 from jupyter_ascending.json_requests import ExecuteRequest
 from jupyter_ascending.json_requests import FocusCellRequest
 from jupyter_ascending.json_requests import GetStatusRequest
+from jupyter_ascending.json_requests import RestartRequest
 from jupyter_ascending.json_requests import SyncRequest
 from jupyter_ascending.notebook.data_types import JupyterCell
 from jupyter_ascending.notebook.data_types import NotebookContents
@@ -162,6 +163,18 @@ def handle_get_status_request(request_type: Type[GetStatusRequest], data: dict) 
     logger.info("Sent get_status")
 
     return f"Updating status"
+
+
+@dispatch_json_request
+def handle_restart_request(request_type: Type[RestartRequest], data: dict) -> str:
+    """JSON-RPC request handler for 'restart'"""
+    request = request_type(**data)
+
+    comm = make_comm()
+    comm.send({"command": "restart_kernel"})
+    logger.info("Sent restart_kernel")
+
+    return f"Restarting kernel in {request.file_name}"
 
 
 NotebookKernelRequestHandler = generate_request_handler("NotebookKernel", notebook_server_methods)

--- a/jupyter_ascending/json_requests.py
+++ b/jupyter_ascending/json_requests.py
@@ -24,6 +24,11 @@ class ExecuteAllRequest(JsonBaseRequest):
 
 
 @dataclass
+class RestartRequest(JsonBaseRequest):
+    pass
+
+
+@dataclass
 class SyncRequest(JsonBaseRequest):
     contents: str
 

--- a/jupyter_ascending/nbextension/static/extension.js
+++ b/jupyter_ascending/nbextension/static/extension.js
@@ -175,6 +175,9 @@ define(["base/js/namespace"], function (Jupyter) {
                         case "status":
                             console.log("give em the status");
                             return;
+                        case "restart_kernel":
+                            Jupyter.notebook.kernel.restart();
+                            return;
                         case "finish_merge":
                             comm.send({command: 'merge_complete'});
                             return;

--- a/jupyter_ascending/requests/restart.py
+++ b/jupyter_ascending/requests/restart.py
@@ -1,0 +1,28 @@
+import argparse
+from pathlib import Path
+
+from loguru import logger
+
+from jupyter_ascending.json_requests import RestartRequest
+from jupyter_ascending.logger import setup_logger
+from jupyter_ascending.requests.client_lib import request_notebook_command
+
+
+def send(file_name: str):
+    logger.info(f"Restarting kernel in file: {file_name}...")
+    file_name = str(Path(file_name).absolute())
+
+    request_obj = RestartRequest(file_name=file_name)
+    request_notebook_command(request_obj)
+
+    logger.info("... Complete")
+
+
+if __name__ == "__main__":
+    setup_logger()
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--filename", help="Filename to send")
+
+    arguments = parser.parse_args()
+    send(arguments.filename)


### PR DESCRIPTION
Tested working.

Adding a single combined command for "restart and run all cells" is unfortunately pretty annoying - because there's not an easy clean way to know when the restart command has finished before executing run all cells. So I'm thinking we start with just separate commands (run all already exists), and see if that meets people's needs well enough?