### PR TITLE
use jupytext to find cell numbers

### DIFF
--- a/jupyter_ascending/requests/execute.py
+++ b/jupyter_ascending/requests/execute.py
@@ -1,5 +1,4 @@
 import argparse
-import re
 from functools import partial
 from pathlib import Path
 from typing import List
@@ -10,36 +9,40 @@ from jupyter_ascending.json_requests import ExecuteRequest
 from jupyter_ascending.logger import setup_logger
 from jupyter_ascending.requests.client_lib import request_notebook_command
 from jupyter_ascending.requests.sync import send as sync_send
+import jupytext
 
-CELL_SEPARATOR_PATTERNS = [
-    re.compile(r"#\s*%%"),
-    re.compile(r"#\s*\+\+"),
-]
+def _find_cell_number(lines: List[str], linenr: int) -> int:
+  linenr = int(linenr)
+  text = '\n'.join(lines)
+  conv = jupytext.jupytext.TextNotebookConverter(jupytext.formats.divine_format(text), None)
+  metadata, jupyter_md, header_cell, pos = jupytext.header.header_to_metadata_and_cell(
+      lines,
+      conv.implementation.header_prefix,
+      conv.implementation.extension,
+      conv.fmt.get(
+          "root_level_metadata_as_raw_cell",
+          conv.config.root_level_metadata_as_raw_cell
+          if conv.config is not None
+          else True,
+      ),
+  )
+  conv.update_fmt_with_notebook_options(metadata, read=True)
+  default_language = jupytext.languages.default_language_from_metadata_and_ext(
+      metadata, conv.implementation.extension)
 
+  lines = lines[pos:]
 
-def _find_cell_number(lines: List[str], line_number: int) -> int:
-    # We need to split cells the same way that jupytext does so that our cell numbers line up.
-    # Unfortunately there's not an obvious way to just use the jupytext parser.
-
-    # The default case has a # %% on the first line. The first cell starts after this.
-    # A second case has no # %% before code begins. The first cell starts immediately.
-    # A third case has a single blank line before the # %%. The blank line is its own cell.
-    if any(pat.match(lines[0]) for pat in CELL_SEPARATOR_PATTERNS):
-        cell_index = -1
-    else:
-        cell_index = 0
-
-    for index, line in enumerate(lines):
-        if any(pat.match(line) for pat in CELL_SEPARATOR_PATTERNS):
-            logger.debug(f"Found another new cell on line number: {index}")
-            cell_index += 1
-            logger.debug(f"    New cell index {cell_index}")
-
-        # Found line number, quit
-        if index == int(line_number):
-            break
-
-    return cell_index
+  cellnr = 0
+  curpos = pos
+  while lines:
+    reader = conv.implementation.cell_reader_class(conv.fmt, default_language)
+    cell, pos = reader.read(lines)
+    curpos += pos
+    lines = lines[pos:]
+    if linenr < curpos:#curpos >= linenr:
+      return cellnr
+    cellnr += 1
+  return -1
 
 
 def send(file_name: str, line_number: int, *args, **kwargs):


### PR DESCRIPTION
Fixes #28 by using jupytext API to find the cell number. Works correctly when tested with the following formats at [mwouts/jupytext/tree/main/demo](https://github.com/mwouts/jupytext/tree/main/demo): Percent `.pct`, Sphinx-gallery `.spx`, Light `.lgt`, Jupyter Markdown `.md`, and R Markdown `.Rmd`.