### PR TITLE
Add tests to #34 (Use jupytext to find cell numbers)

### DIFF
--- a/jupyter_ascending/requests/execute.py
+++ b/jupyter_ascending/requests/execute.py
@@ -4,48 +4,51 @@ from pathlib import Path
 from typing import List
 
 from loguru import logger
+import jupytext
 
 from jupyter_ascending.json_requests import ExecuteRequest
 from jupyter_ascending.logger import setup_logger
 from jupyter_ascending.requests.client_lib import request_notebook_command
 from jupyter_ascending.requests.sync import send as sync_send
-import jupytext
 
-def _find_cell_number(lines: List[str], linenr: int) -> int:
-  linenr = int(linenr)
-  text = '\n'.join(lines)
-  conv = jupytext.jupytext.TextNotebookConverter(jupytext.formats.divine_format(text), None)
-  metadata, jupyter_md, header_cell, pos = jupytext.header.header_to_metadata_and_cell(
-      lines,
-      conv.implementation.header_prefix,
-      conv.implementation.extension,
-      conv.fmt.get(
-          "root_level_metadata_as_raw_cell",
-          conv.config.root_level_metadata_as_raw_cell
-          if conv.config is not None
-          else True,
-      ),
-  )
-  conv.update_fmt_with_notebook_options(metadata, read=True)
-  default_language = jupytext.languages.default_language_from_metadata_and_ext(
-      metadata, conv.implementation.extension)
 
-  lines = lines[pos:]
+def _find_cell_number(lines: List[str], line_number: int) -> int:
+    """Implementation closely copied from jupytext.
 
-  cellnr = 0
-  curpos = pos
-  while lines:
-    reader = conv.implementation.cell_reader_class(conv.fmt, default_language)
-    cell, pos = reader.read(lines)
-    curpos += pos
+    See https://github.com/mwouts/jupytext/blob/main/jupytext/jupytext.py#L138
+    """
+    text = "\n".join(lines)
+    conv = jupytext.jupytext.TextNotebookConverter(
+        jupytext.formats.divine_format(text), None
+    )
+    (metadata, _, _, pos,) = jupytext.header.header_to_metadata_and_cell(
+        lines,
+        conv.implementation.header_prefix,
+        conv.implementation.extension,
+        conv.fmt.get(
+            "root_level_metadata_as_raw_cell",
+            conv.config.root_level_metadata_as_raw_cell
+            if conv.config is not None
+            else True,
+        ),
+    )
+    conv.update_fmt_with_notebook_options(metadata, read=True)
+    default_language = jupytext.languages.default_language_from_metadata_and_ext(
+        metadata, conv.implementation.extension
+    )
+
     lines = lines[pos:]
-    if linenr < curpos:#curpos >= linenr:
-      return cellnr
-    cellnr += 1
-  return -1
+    num_lines_read, cell_number = pos, 0
+    reader = conv.implementation.cell_reader_class(conv.fmt, default_language)
+    while lines and num_lines_read < line_number:
+        _, pos = reader.read(lines)
+        num_lines_read += pos
+        cell_number += 1
+        lines = lines[pos:]
+    return max(0, cell_number - 1)
 
 
-def send(file_name: str, line_number: int, *args, **kwargs):
+def send(file_name: str, line_number: int):
     logger.debug("Starting execute request")
 
     # Always pass absolute path
@@ -53,7 +56,7 @@ def send(file_name: str, line_number: int, *args, **kwargs):
 
     request_obj = partial(ExecuteRequest, file_name=file_name, contents="")
 
-    with open(file_name, "r") as reader:
+    with open(file_name, "r", encoding="utf8") as reader:
         lines = reader.readlines()
 
     cell_index = _find_cell_number(lines, line_number)
@@ -69,7 +72,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--filename", help="Filename to send")
-    parser.add_argument("--linenumber", help="Line number that the cursor is currently on")
+    parser.add_argument(
+        "--linenumber", type=int, help="Line number that the cursor is currently on"
+    )
 
     arguments = parser.parse_args()
 

--- a/jupyter_ascending/requests/execute.py
+++ b/jupyter_ascending/requests/execute.py
@@ -1,5 +1,4 @@
 import argparse
-import re
 from functools import partial
 from pathlib import Path
 from typing import List
@@ -10,36 +9,40 @@ from jupyter_ascending.json_requests import ExecuteRequest
 from jupyter_ascending.logger import setup_logger
 from jupyter_ascending.requests.client_lib import request_notebook_command
 from jupyter_ascending.requests.sync import send as sync_send
+import jupytext
 
-CELL_SEPARATOR_PATTERNS = [
-    re.compile(r"#\s*%%"),
-    re.compile(r"#\s*\+\+"),
-]
+def _find_cell_number(lines: List[str], linenr: int) -> int:
+  linenr = int(linenr)
+  text = '\n'.join(lines)
+  conv = jupytext.jupytext.TextNotebookConverter(jupytext.formats.divine_format(text), None)
+  metadata, jupyter_md, header_cell, pos = jupytext.header.header_to_metadata_and_cell(
+      lines,
+      conv.implementation.header_prefix,
+      conv.implementation.extension,
+      conv.fmt.get(
+          "root_level_metadata_as_raw_cell",
+          conv.config.root_level_metadata_as_raw_cell
+          if conv.config is not None
+          else True,
+      ),
+  )
+  conv.update_fmt_with_notebook_options(metadata, read=True)
+  default_language = jupytext.languages.default_language_from_metadata_and_ext(
+      metadata, conv.implementation.extension)
 
+  lines = lines[pos:]
 
-def _find_cell_number(lines: List[str], line_number: int) -> int:
-    # We need to split cells the same way that jupytext does so that our cell numbers line up.
-    # Unfortunately there's not an obvious way to just use the jupytext parser.
-
-    # The default case has a # %% on the first line. The first cell starts after this.
-    # A second case has no # %% before code begins. The first cell starts immediately.
-    # A third case has a single blank line before the # %%. The blank line is its own cell.
-    if any(pat.match(lines[0]) for pat in CELL_SEPARATOR_PATTERNS):
-        cell_index = -1
-    else:
-        cell_index = 0
-
-    for index, line in enumerate(lines):
-        if any(pat.match(line) for pat in CELL_SEPARATOR_PATTERNS):
-            logger.debug(f"Found another new cell on line number: {index}")
-            cell_index += 1
-            logger.debug(f"    New cell index {cell_index}")
-
-        # Found line number, quit
-        if index == int(line_number):
-            break
-
-    return cell_index
+  cellnr = 0
+  curpos = pos
+  while lines:
+    reader = conv.implementation.cell_reader_class(conv.fmt, default_language)
+    cell, pos = reader.read(lines)
+    curpos += pos
+    lines = lines[pos:]
+    if linenr < curpos:#curpos >= linenr:
+      return cellnr
+    cellnr += 1
+  return -1
 
 
 def send(file_name: str, line_number: int, *args, **kwargs):

--- a/jupyter_ascending/tests/test_execute_request.py
+++ b/jupyter_ascending/tests/test_execute_request.py
@@ -2,40 +2,53 @@ from jupyter_ascending.requests.execute import _find_cell_number
 
 
 def test_find_cell_number():
-    assert (
-        _find_cell_number(
-            [
-                "\n",
-                "# %%\n",
-                "print('hello')\n",
-                "print('wow!')",
-                "# %%\n" "TARGET = True",
-                "\n",
-                "# %%",
-                "# Too Far",
-                "# Still too far",
-            ],
-            5,
-        )
-        == 1
-    )
+    filetext = """# %%  # Line 1, Cell 0
+print("Hello, world!")  # Line 2, Cell 0
+# %%                    # Line 3, Cell 1
+print("Goodby, world!") # Line 4, Cell 1
+"""
+    lines = filetext.splitlines()
+    assert _find_cell_number(lines, 0) == 0
+    assert _find_cell_number(lines, 1) == 0
+    assert _find_cell_number(lines, 2) == 0
+    assert _find_cell_number(lines, 3) == 1
+    assert _find_cell_number(lines, 4) == 1
 
 
-def test_find_cell_number_with_more_spaces():
-    assert (
-        _find_cell_number(
-            [
-                "\n",
-                "#     %%\n",
-                "print('hello')\n",
-                "print('wow!')",
-                "# %%\n" "TARGET = True",
-                "\n",
-                "# %%",
-                "# Too Far",
-                "# Still too far",
-            ],
-            5,
-        )
-        == 1
-    )
+def test_find_cell_number_with_optional_yaml_header():
+    filetext = """# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.3.4
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %%                   # Line 15, Cell 0
+print("Hello, world!") # Line 16, Cell 0
+                       # Line 17, Cell 0
+# %%                   # Line 18, Cell 1
+print("Goodbye, ...")  # Line 19, Cell 1
+                       # Line 20, Cell 1
+print("world!")        # Line 21, Cell 1
+                       # Line 22, Cell 1
+
+"""
+    lines = filetext.splitlines()
+    assert _find_cell_number(lines, 0) == 0
+    assert _find_cell_number(lines, 1) == 0
+    assert _find_cell_number(lines, 14) == 0
+    assert _find_cell_number(lines, 15) == 0
+    assert _find_cell_number(lines, 16) == 0
+    assert _find_cell_number(lines, 18) == 1
+    assert _find_cell_number(lines, 21) == 1
+    # Line 23 and 25 - blank line and beyond EOF.
+    # Both return the last cell.
+    assert _find_cell_number(lines, 23) == 1
+    assert _find_cell_number(lines, 25) == 1


### PR DESCRIPTION
Ran into Issue #28  while working on an [Emacs package for this](https://github.com/eihli/jupyter_ascending.el). Saw Anjiro already had a PR open at #34. This adds tests, addresses some lint issues, and has a few other minor adjustments like setting the `type=int` in the `parser.add_argument` for `line_number`.