### PR TITLE
Replace edlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ python -m jupyter serverextension enable jupyter_ascending --sys-prefix --py
 
 You can confirm it's installed by checking for `jupyter_ascending` in:
 ```
-$ jupyter nbextension     list
-$ jupyter serverextension list
+$ python -m jupyter nbextension     list
+$ python -m jupyter serverextension list
 ```
 
 If your jupyter setup includes multiple python kernels that you'd like to use with jupyter ascending, you'll need to complete this setup in each of those python environments separately.
@@ -42,7 +42,7 @@ If your jupyter setup includes multiple python kernels that you'd like to use wi
 
 2) Start jupyter and open the notebook:
 
-   `jupyter notebook example.sync.ipynb`
+   `python -m jupyter notebook example.sync.ipynb`
 
 
 3) Add some code to the `.sync.py` file, e.g.

--- a/jupyter_ascending/_version.py
+++ b/jupyter_ascending/_version.py
@@ -5,5 +5,5 @@
 # Distributed under the terms of the Modified BSD License.
 
 # NOTE: Must keep in sync w/ pyproject.toml to publish
-version_info = (0, 1, 25)
+version_info = (0, 1, 26)
 __version__ = ".".join(map(str, version_info))

--- a/jupyter_ascending/notebook/merge.py
+++ b/jupyter_ascending/notebook/merge.py
@@ -10,7 +10,7 @@ from typing import Tuple
 from typing import Union
 
 import attr
-import edlib
+import editdistance
 
 from jupyter_ascending.notebook.data_types import CellMovements
 from jupyter_ascending.notebook.data_types import JupyterCell
@@ -221,7 +221,7 @@ class LevenshteinDistance(BaseStringDistancer):
     @staticmethod
     def find_distance(string_1: str, string_2: str) -> int:
         # TODO: Maybe use jaro winkler instead
-        return edlib.align(string_1, string_2)["editDistance"]
+        return editdistance.eval(string_1, string_2)
 
     @staticmethod
     def sort_function(distance: CellDistance) -> Number:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "jupyter_ascending"
 # Make sure to also update _version.py when doing version bump.
-version = "0.1.25"
+version = "0.1.26"
 description = ""
 authors = ["Josh Albrecht <joshalbrecht@gmail.com>", "TJ DeVries <devries.timothyj@gmail.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ jupytext = "^1.14.4"
 jsonrpcserver = "^5.0.9"
 jsonrpcclient = "^4.0.3"
 loguru = ">=0.4.1"
-edlib = "^1.3.8"
+editdistance = "^0.6.2"
 requests = "^2.31.0"
 aiohttp = "^3.8.4"
 


### PR DESCRIPTION
[`edlib`](https://github.com/Martinsos/edlib) doesn't have wheels or build cleanly on macs on python 3.11, and appears kinda stale. This replaces it with https://github.com/roy-ht/editdistance which seems slightly better. 

Ran the test suite and also tested the basic syncing manually.